### PR TITLE
Upgrade to ADEdtPdv R3.8.4, update RELEASE_NOTES for R2.3.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,7 @@
 # Release Notes for ioc/common/edtCam
+R2.3.0: 2024-08-20 Michael Skoufis 
+	Update to ADEdtPdv R3.8.4
+
 R2.2.0: 2022-01-29 Bruce Hill
 	Update archive file each time IOC boots
 	Update to base/R7.0.3.1-2.0, ADCore/R3.9-1.0.3, and other latest modules.

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -7,7 +7,7 @@ include $(TOP)/RELEASE_SITE
 # IOC apps or other Support apps
 # ===============================================================
 ADCORE_MODULE_VERSION               = R3.10-1.1.0
-ADEDTPDV_MODULE_VERSION             = R3.8.3
+ADEDTPDV_MODULE_VERSION             = R3.8.4
 ADSTREAM_MODULE_VERSION             = R3.1.2
 ADSUPPORT_MODULE_VERSION            = R1.9-0.1.0
 ASYNGENICAM_MODULE_VERSION          = R1.2.1


### PR DESCRIPTION

## Description
Upgrade ADEdtPdv module version in configure/RELEASE to R3.8.4 (supports EDT driver R5.6.7.0).

## Motivation and Context
This work is done as part of improving the performance of the ORCA-Flash4.0 V3 camera in the XRT spectrometer.

## How Has This Been Tested?
Prior testing involved IOC testing (ensure IOC boots normally, fix initialization errors, etc.) and image acquisition in the 120Hz mode.  Some testing is still on-going.

## Where Has This Been Documented?
https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=407244447

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
