### PR TITLE
Fix default values for Orca GoTo120Hz mode

### DIFF
--- a/edtApp/Db/cannedSequences.db
+++ b/edtApp/Db/cannedSequences.db
@@ -11,7 +11,7 @@
 record( ao, "$(CAM):Def120HzTrigDelay" )
 {
     field( DESC, "Default trigger delay" )
-    field( DOL,  "1.0e-6" )
+    field( DOL,  "5.1e-3" )
     field( PINI, "YES" )
     field( PREC, "5" )
 	info( autosaveFields, "DESC PREC VAL" )
@@ -20,7 +20,7 @@ record( ao, "$(CAM):Def120HzTrigDelay" )
 record( ao, "$(CAM):Def120HzExposure" )
 {
     field( DESC, "Default exposure" )
-	field( DOL,  "1.0e-3" )
+	field( DOL,  "4.1e-4" )
     field( PINI, "YES" )
     field( PREC, "5" )
 	info( autosaveFields, "DESC PREC VAL" )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
During Orca V3 testing Mike Skoufis and I discovered that the default values for the
GoTo120Hz sequence were wrong.   This is because the appropriate defaults
were determined during early testing and autosaved on the few IOCs that we used to test and deploy Orca cameras.
Thus no one noticed this problem till Mike created a new Orca IOC.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I don't know of an open issue re this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using Mike's test IOC.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
